### PR TITLE
fix: update test console path for .NET 8 framework

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,13 +62,13 @@ jobs:
         run: |
           echo "Test standalone console with sample model"
           cp "./src/Ironbug.HVAC_Tests/TestSource/Integration Testing/FourOfficeBuilding.osm" "./src/Ironbug.HVAC_Tests/TestSource/Integration Testing/test.osm"
-          ./src/Ironbug.Console/bin/x64/Release/Ironbug.Console.exe "./src/Ironbug.HVAC_Tests/TestSource/Integration Testing/test.osm" "./src/Ironbug.HVAC_Tests/TestSource/Integration Testing/Sys01_PTAC_AllElec.json"
+          ./src/Ironbug.Console/bin/x64/Release/net8/Ironbug.Console.exe "./src/Ironbug.HVAC_Tests/TestSource/Integration Testing/test.osm" "./src/Ironbug.HVAC_Tests/TestSource/Integration Testing/Sys01_PTAC_AllElec.json"
 
           echo "Test console with GH plugin"
           mkdir "C:/Program Files/ladybug_tools/openstudio/CSharp/openstudio"
           cp ./src/Ironbug.Console/bin/x64/Release/openstudio* "C:/Program Files/ladybug_tools/openstudio/CSharp/openstudio"
           cp "./src/Ironbug.HVAC_Tests/TestSource/Integration Testing/FourOfficeBuilding.osm" "./src/Ironbug.HVAC_Tests/TestSource/Integration Testing/test2.osm"
-          ./src/Ironbug.Console/bin/x64/Release/Ironbug.Console.exe "./src/Ironbug.HVAC_Tests/TestSource/Integration Testing/test2.osm" "./src/Ironbug.HVAC_Tests/TestSource/Integration Testing/Sys01_PTAC_AllElec.json"
+          ./src/Ironbug.Console/bin/x64/Release/net8/Ironbug.Console.exe "./src/Ironbug.HVAC_Tests/TestSource/Integration Testing/test2.osm" "./src/Ironbug.HVAC_Tests/TestSource/Integration Testing/Sys01_PTAC_AllElec.json"
 
       - name: zip plugin
         shell: bash
@@ -152,7 +152,7 @@ jobs:
         run: |
           echo "Test standalone console with sample model"
           cp "./src/Ironbug.HVAC_Tests/TestSource/Integration Testing/FourOfficeBuilding.osm" "./src/Ironbug.HVAC_Tests/TestSource/Integration Testing/test.osm"
-          ./src/Ironbug.Console/bin/Release/linux-x64/Ironbug.Console "./src/Ironbug.HVAC_Tests/TestSource/Integration Testing/test.osm" "./src/Ironbug.HVAC_Tests/TestSource/Integration Testing/Sys01_PTAC_AllElec.json"
+          ./src/Ironbug.Console/bin/Release/linux-x64/net8/Ironbug.Console "./src/Ironbug.HVAC_Tests/TestSource/Integration Testing/test.osm" "./src/Ironbug.HVAC_Tests/TestSource/Integration Testing/Sys01_PTAC_AllElec.json"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- Update console executable path for Windows and Linux platforms
- Replace 'x64/Release' with 'x64/Release/net8' for Windows
- Replace 'Release/linux-x64' with 'Release/linux-x64/net8' for Linux