### PR TITLE
Dev

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,7 +82,7 @@ jobs:
       - name: zip plugin - net8
         shell: bash
         run: |
-          mkdir ./ironbug-rhino7
+          mkdir ./ironbug-net8
           cp ./installer/plugin-net8/* ./ironbug-net8 -r
           cp ./installer/HVACTemplates ./ironbug-net8 -r
           7z a -tzip ironbug-net8.zip ./ironbug-net8

--- a/src/Ironbug.HVAC/Loops/IB_PlantLoop.cs
+++ b/src/Ironbug.HVAC/Loops/IB_PlantLoop.cs
@@ -205,15 +205,8 @@ namespace Ironbug.HVAC
         public bool Equals(IB_PlantLoop other)
         {
             if (!base.Equals(other))
-            {
-                //var otherJ = other?.ToJson();
-                //var thisJ = this?.ToJson();
-
                 return false;
-                //var same = this.Equals(other);
-                //return false;
-            }
-              
+
 
             if (this.SizingPlant != other.SizingPlant)
                 return false;


### PR DESCRIPTION
- Update folder name from 'ironbug-rhino7' to 'ironbug-net8' in the release workflow
- This change ensures consistency between the workflow steps and the correct folder name